### PR TITLE
Fix variable not defined issue when first run benchmark

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -41,7 +41,7 @@ python -m vllm.entrypoints.openai.api_server \
 Adjust the `tensor_parallel_size` parameter based on your available devices.
 ### Optional : Start SGLang server/router
 
-Since the evaluation could takes more days, we also suggested using SGLang with data parallelism to accelerate the evaluation.
+Since the evaluation could takes days, we also suggest using SGLang with data parallelism to accelerate the evaluation. Refer to [SGLang documentation](https://docs.sglang.ai/router/router.html) for more details.
 ```bash
 # Use router to support better data parallelism
 python -m sglang_router.launch_server --model-path Qwen/QwQ-32B --dp-size 4 --host=0.0.0.0 --port=30000

--- a/eval/README.md
+++ b/eval/README.md
@@ -38,13 +38,14 @@ python -m vllm.entrypoints.openai.api_server \
     --enforce-eager \
     --port 8030
 ```
+Adjust the `tensor_parallel_size` parameter based on your available devices.
 ### Optional : Start SGLang server/router
 ```bash
-# Use router for better data parallelism
+# Use router to support better data parallelism
 python -m sglang_router.launch_server --model-path Qwen/QwQ-32B --dp-size 4 --host=0.0.0.0 --port=30000
 
 ```
-Also adjust the port in following commands.
+Adjust the `dp_size` parameter based on your available devices. Also adjust the port in following commands.
 
 ### Step 2: Run Inference
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -40,6 +40,8 @@ python -m vllm.entrypoints.openai.api_server \
 ```
 Adjust the `tensor_parallel_size` parameter based on your available devices.
 ### Optional : Start SGLang server/router
+
+Since the evaluation could takes more days, we also suggested using SGLang with data parallelism to accelerate the evaluation.
 ```bash
 # Use router to support better data parallelism
 python -m sglang_router.launch_server --model-path Qwen/QwQ-32B --dp-size 4 --host=0.0.0.0 --port=30000

--- a/eval/README.md
+++ b/eval/README.md
@@ -38,8 +38,13 @@ python -m vllm.entrypoints.openai.api_server \
     --enforce-eager \
     --port 8030
 ```
+### Optional : Start SGLang server/router
+```bash
+# Use router for better data parallelism
+python -m sglang_router.launch_server --model-path Qwen/QwQ-32B --dp-size 4 --host=0.0.0.0 --port=30000
 
-Adjust the `tensor_parallel_size` parameter based on your available devices.
+```
+Also adjust the port in following commands.
 
 ### Step 2: Run Inference
 

--- a/eval/generate_api_answers/infer_multithread.py
+++ b/eval/generate_api_answers/infer_multithread.py
@@ -60,7 +60,7 @@ def main():
         print(f"Found {total_completed} completed samples from previous run")
     else:
         with open(args.output_file, 'w', encoding='utf-8') as g:
-            pass
+            completed_counts = dict()
 
     expanded_data = []
     for item in data:


### PR DESCRIPTION
## Bug Description

When first run benchmark, the `completed_counts` is not assigned.
```
Traceback (most recent call last):
  File "./generate_api_answers/infer_multithread.py", line 96, in <module>
    main()
  File "./generate_api_answers/infer_multithread.py", line 68, in main
    completed = completed_counts.get(prompt, 0)
UnboundLocalError: local variable 'completed_counts' referenced before assignment
```

